### PR TITLE
Fixing paths because they were not escaping a character properlly

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Download the Windows WIP version of IceStudio **icestudio-0.5.1w202106050906** f
 The required files are included already in the nightly version of IceStudio, so yopu can go to the APPIO section directly.
 
 **APIO**
-1)  In the folder   -> **C:\Users\your_user\.icestudio\apio\packages**  
+1)  In the folder   -> **C:\Users\your_user\\.icestudio\apio\packages**  
 Add the files of [toolchain-ecp5.zip](https://github.com/benitoss/ColorLight_FPGA_boards/blob/main/Icestudio_update_boards/toolchain-ecp5.zip?raw=true) file
-2)  In the folder    --> **C:\Users\your_user\.icestudio\apio**  
+2)  In the folder    --> **C:\Users\your_user\\.icestudio\apio**  
 Overwrite profile.json file of [profile.zip](https://github.com/benitoss/ColorLight_FPGA_boards/blob/main/Icestudio_update_boards/profile.zip?raw=true) file
-3)   In the folder   --> **C:\Users\your_user\.icestudio\venv\Lib\site-packages\apio\resources**  
+3)   In the folder   --> **C:\Users\your_user\\.icestudio\venv\Lib\site-packages\apio\resources**  
 Overwrite programmers.json y boards.json  files of [resources.zip](https://github.com/benitoss/ColorLight_FPGA_boards/blob/main/Icestudio_update_boards/resources.zip?raw=true) file
-4)  In the folder  --> **C:\Users\your_user\.icestudio\venv\Lib\site-packages\apio**  
+4)  In the folder  --> **C:\Users\your_user\\.icestudio\venv\Lib\site-packages\apio**  
 Overwrite util.py file of [util.zip](https://github.com/benitoss/ColorLight_FPGA_boards/blob/main/Icestudio_update_boards/util.zip?raw=true) file
 
 # JTAG Programmers


### PR DESCRIPTION
Creating this pull request for fixing the paths. I think the system didn't parse the \. sequence and it was needed to scape as \\.